### PR TITLE
handle two mutually incompatible versions of coverage

### DIFF
--- a/coverage_lcov/converter.py
+++ b/coverage_lcov/converter.py
@@ -14,6 +14,14 @@ from coverage.results import Analysis
 log = logging.getLogger("coverage_lcov.converter")
 
 
+def _unpack_file_reporters(file_reporters):
+    """Get just the file reporter from the list."""
+    return [
+        fr if isinstance(fr, PythonFileReporter) else fr[0]
+        for fr in file_reporters
+    ]
+
+
 def GlobMatcher_compat(pattern, name):
     """Cross-version compatibility function.
 
@@ -45,8 +53,10 @@ class Converter:
     def get_file_reporters(self) -> List[Union[PythonFileReporter, Any]]:
         file_reporters: List[
             Union[PythonFileReporter, Any]
-        ] = self.cov_obj._get_file_reporters(  # pylint: disable=protected-access
-            None
+        ] = _unpack_file_reporters(
+                self.cov_obj._get_file_reporters(  # pylint: disable=protected-access
+                None
+            )
         )
         config = self.cov_obj.config
 

--- a/coverage_lcov/converter.py
+++ b/coverage_lcov/converter.py
@@ -57,7 +57,7 @@ class Converter:
             file_reporters = [fr for fr in file_reporters if matcher.match(fr.filename)]
 
         if config.report_omit:
-            matcher = GlobMatcher_compat(  # pylint: disable=too-many-function-args
+            matcher = GlobMatcher_compat(
                 prep_patterns(config.report_omit), "report_omit"
             )
             file_reporters = [

--- a/coverage_lcov/converter.py
+++ b/coverage_lcov/converter.py
@@ -14,11 +14,11 @@ from coverage.results import Analysis
 log = logging.getLogger("coverage_lcov.converter")
 
 
-def _unpack_file_reporter(file_reporter):
+def _unpack_file_reporter(fr):
     """Get just the file reporter from potentially a tupled of fr and morf."""
     return fr if isinstance(fr, PythonFileReporter) else fr[0]
 
-def _unpack_morf(file_reporter):
+def _unpack_morf(fr):
     """Get just the morf from potentially a tupled of fr and morf."""
     return fr if isinstance(fr, PythonFileReporter) else fr[1]
 

--- a/coverage_lcov/converter.py
+++ b/coverage_lcov/converter.py
@@ -34,15 +34,25 @@ class Converter:
         config = self.cov_obj.config
 
         if config.report_include:
-            matcher = FnmatchMatcher(  # pylint: disable=too-many-function-args
-                prep_patterns(config.report_include), "report_include"
-            )
+            try:
+                matcher = FnmatchMatcher(  # pylint: disable=too-many-function-args
+                    prep_patterns(config.report_include), "report_include"
+                )
+            except TypeError:
+                matcher = FnmatchMatcher(  # pylint: disable=too-many-function-args
+                    prep_patterns(config.report_include),
+                )
             file_reporters = [fr for fr in file_reporters if matcher.match(fr.filename)]
 
         if config.report_omit:
-            matcher = FnmatchMatcher(  # pylint: disable=too-many-function-args
-                prep_patterns(config.report_omit), "report_omit"
-            )
+            try:
+                matcher = FnmatchMatcher(  # pylint: disable=too-many-function-args
+                    prep_patterns(config.report_omit), "report_omit"
+                )
+            except TypeError:
+                matcher = FnmatchMatcher(  # pylint: disable=too-many-function-args
+                    prep_patterns(config.report_omit),
+                )
             file_reporters = [
                 fr for fr in file_reporters if not matcher.match(fr.filename)
             ]

--- a/coverage_lcov/converter.py
+++ b/coverage_lcov/converter.py
@@ -97,11 +97,12 @@ class Converter:
                 analysis = self.cov_obj._analyze(  # pylint: disable=protected-access
                     _unpack_morf(file_reporter)
                 )
-                token_lines = analysis.file_reporter.source_token_lines()
+                fr = _unpack_file_reporter(file_reporter)
+                token_lines = fr.source_token_lines()
                 if self.relative_path:
-                    filename = file_reporter.relative_filename()
+                    filename = fr.relative_filename()
                 else:
-                    filename = file_reporter.filename
+                    filename = fr.filename
                 output += "TN:\n"
                 output += f"SF:{filename}\n"
 


### PR DESCRIPTION
Hi, thanks for this tool!

I am having a problem with conda installing coveralls and coverage-lcov. I think the reason is that coveralls is not yet compatible with the two-argument FnmatchMatcher call, see https://github.com/TheKevJames/coveralls-python/pull/340, while coverage-lcov is only compatible with the two-argument FnmatchMatcher call. This means that I cannot get both to work in github actions.

On python 3.11, conda installing coveralls and coverage-lcov from conda-forge gives:
```
The following package could not be installed
└─ coverage-lcov is installable and it requires
   └─ coverage <6.0,>=5.5  with the potential options
      ├─ coverage 5.5 would require
      │  └─ python >=3.6,<3.7.0a0 , which can be installed;
      ├─ coverage 5.5 would require
      │  └─ python >=3.7,<3.8.0a0 , which can be installed;
      ├─ coverage 5.5 would require
      │  └─ python >=3.8,<3.9.0a0 , which can be installed;
      ├─ coverage 5.5 would require
      │  └─ python >=3.9,<3.10.0a0 , which can be installed;
      └─ coverage 5.5 would require
         └─ python >=3.10,<3.11.0a0 , which can be installed.
```

In any case, one can force an install (e.g., with pip).

One working solution is to delete the second argument from the installed python script:
`sed --in-place -e 's,"report_include",,g' -e 's,"report_omit",,g' /usr/share/miniconda/envs/*/lib/python*/site-packages/coverage_lcov/converter.py`

A perhaps slightly cleaner solution is provided by this PR. It puts a try-catch around the FnmatchMatcher, so that both the two-argument and one-argument calls are tried.

This may enable wider version compatibility. In any case, I think a new version of coverage-lcov should be released to conda with up-to-date coverage compatibility information.